### PR TITLE
feat: add error type guard

### DIFF
--- a/error.test.ts
+++ b/error.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { assertError, isError } from "./error";
+
+describe("error", () => {
+	describe("isError", () => {
+		it("should return true", () => {
+			expect(isError(new Error())).toBe(true);
+		});
+
+		it("should return false", () => {
+			expect(isError(0)).toBe(false);
+			expect(isError("")).toBe(false);
+			expect(isError([])).toBe(false);
+			expect(isError({})).toBe(false);
+			expect(isError(null)).toBe(false);
+			expect(isError(undefined)).toBe(false);
+			expect(isError(true)).toBe(false);
+			expect(isError(false)).toBe(false);
+		});
+
+		describe("assertError", () => {
+			it.each([1, "", [], {}, null, undefined, true, false])("should throw type error %s", (value) => {
+				expect(() => assertError(value)).toThrow(TypeError);
+				expect(() => assertError(value)).toThrow(/Expected an error/);
+			});
+
+			it.each([new Error()])("should not throw type error %s", (value) => {
+				expect(() => assertError(value)).not.toThrow();
+			});
+
+			it("should throw custom error message", () => {
+				const customMessage = "Custom error message";
+
+				expect(() => assertError("123", customMessage)).toThrow(TypeError);
+				expect(() => assertError("123", customMessage)).toThrow(customMessage);
+			});
+		});
+	});
+});

--- a/error.ts
+++ b/error.ts
@@ -1,0 +1,10 @@
+export function isError(value: unknown): value is Error {
+	return value instanceof Error;
+}
+
+export function assertError(
+	value: unknown,
+	message = `Expected an error, received ${typeof value}`,
+): asserts value is string {
+	if (!isError(value)) throw new TypeError(message);
+}

--- a/error.ts
+++ b/error.ts
@@ -5,6 +5,6 @@ export function isError(value: unknown): value is Error {
 export function assertError(
 	value: unknown,
 	message = `Expected an error, received ${typeof value}`,
-): asserts value is string {
+): asserts value is Error {
 	if (!isError(value)) throw new TypeError(message);
 }

--- a/number.test.ts
+++ b/number.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { assertNumber, isNumber } from "./number";
 
 describe("number", () => {
-	describe("isUmber", () => {
+	describe("isNumber", () => {
 		it("should return true", () => {
 			expect(isNumber(NaN)).toBe(true);
 			expect(isNumber(Infinity)).toBe(true);

--- a/number.test.ts
+++ b/number.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { assertNumber, isNumber } from "./number";
 
 describe("number", () => {
-	describe("isuUmber", () => {
+	describe("isUmber", () => {
 		it("should return true", () => {
 			expect(isNumber(NaN)).toBe(true);
 			expect(isNumber(Infinity)).toBe(true);

--- a/number.ts
+++ b/number.ts
@@ -6,5 +6,5 @@ export function assertNumber(
 	value: unknown,
 	message = `Expected a number, received ${typeof value}`,
 ): asserts value is number {
-	if (typeof value !== "number") throw new TypeError(message);
+	if (!isNumber(value)) throw new TypeError(message);
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
 	"type": "module",
 	"exports": {
 		"./string": "./string.ts",
-		"./number": "./number.ts"
+		"./number": "./number.ts",
+		"./error": "./error.ts"
 	},
 	"scripts": {
 		"lint": "biome lint .",

--- a/string.ts
+++ b/string.ts
@@ -6,5 +6,5 @@ export function assertString(
 	value: unknown,
 	message = `Expected a string, received ${typeof value}`,
 ): asserts value is string {
-	if (typeof value !== "string") throw new TypeError(message);
+	if (!isString(value)) throw new TypeError(message);
 }


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.2.2--canary.5.b71d944.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install type-guardians@1.2.2--canary.5.b71d944.0
  # or 
  yarn add type-guardians@1.2.2--canary.5.b71d944.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
